### PR TITLE
Add an openrc init file

### DIFF
--- a/minecraftd.openrc.in
+++ b/minecraftd.openrc.in
@@ -1,0 +1,20 @@
+#!/sbin/openrc-run
+
+command=/usr/bin/@INAME@
+command_user="@GAME_USER@:@GAME_USER@"
+pidfile=/run/@INAME@.pid
+
+start() {
+	/usr/bin/@INAME@ start
+}
+
+stop() {
+	/usr/bin/@INAME@ stop
+}
+
+depend() {
+	need net
+}
+
+name="@INAME@"
+description="@GAME@ Server"


### PR DESCRIPTION
I needed an openrc-init file as I run Artix Linux and as init files belong to upstream... Here I make a MR.

Although I didn't knew how to deal with it in the makefile... I guess we should not install it by default but have a way to compile it and then make another package call minecraft-server-openrc which install this init file and pull minecraft-server as a dependency :)

I marked it as draft to let you deal with it as you like, or not dealing with it if you don't want to bother ;)