### PR TITLE
Update minecraftd.sh.in to prevent IDLE_SERVER=true to stop the server even if player are still online

### DIFF
--- a/minecraftd.sh.in
+++ b/minecraftd.sh.in
@@ -128,7 +128,7 @@ idle_server_daemon() {
 			if [[ -n "$(tmux -L "${SESSION_NAME}" list-clients -t "${SESSION_NAME}":0.0 2> /dev/null)" ]]; then
 				# An administrator is connected to the console, pause player checking
 				echo "An admin is connected to the console. Pause player checking."
-			elif SUDO_CMD=("") is_player_online; then
+			elif SUDO_CMD=() is_player_online; then
 				# No player was seen on the server through list
 				no_player=$(( no_player + CHECK_PLAYER_TIME ))
 				# Stop the game server if no player was active for at least ${IDLE_IF_TIME}


### PR DESCRIPTION
The check that list the user is not working since the hardening of sudo. So the server stop even if player are online.

I think remove the "" solve the issue.