### PR TITLE
Fix server stop for IDLE_SERVER=true even if player are online

### DIFF
--- a/minecraftd.sh.in
+++ b/minecraftd.sh.in
@@ -128,7 +128,7 @@ idle_server_daemon() {
 			if [[ -n "$(tmux -L "${SESSION_NAME}" list-clients -t "${SESSION_NAME}":0.0 2> /dev/null)" ]]; then
 				# An administrator is connected to the console, pause player checking
 				echo "An admin is connected to the console. Pause player checking."
-			elif SUDO_CMD=("") is_player_online; then
+			elif is_player_online; then
 				# No player was seen on the server through list
 				no_player=$(( no_player + CHECK_PLAYER_TIME ))
 				# Stop the game server if no player was active for at least ${IDLE_IF_TIME}


### PR DESCRIPTION
I try to change "SUDO_CMD=("")" to "SUDO_CMD=()" but it's not fixing the issue.  Remove this "SUDO_CMD=" fix the issue and it seems useless since the function "idle_server_daemon" is only call with the minecraft game user and so its already set to "SUDO_CMD=()"