### PR TITLE
Replace "gawk" with "awk" to allow symlinks

### DIFF
--- a/minecraftd.sh.in
+++ b/minecraftd.sh.in
@@ -313,7 +313,7 @@ server_status() {
 		# Calculating memory usage
 		for p in $("${SUDO_CMD[@]}" pgrep -f "${MAIN_EXECUTABLE}"); do
 			ps -p"${p}" -O rss | tail -n 1;
-		done | gawk '{ count ++; sum += $2 }; END {count --; print "Number of processes =", count, "(tmux +", count, "x server)"; print "Total memory usage =", sum/1024, "MB" ;};'
+		done | awk '{ count ++; sum += $2 }; END {count --; print "Number of processes =", count, "(tmux +", count, "x server)"; print "Total memory usage =", sum/1024, "MB" ;};'
 	else
 		echo -e "Status:\e[39;1m stopped\e[0m"
 	fi


### PR DESCRIPTION
Allows for different awk interpreters to be used via symlinks instead of calling gawk specifically. To the best of my knowledge and testing, the common interpreters (gawk, mawk, nawk) can be called by awk instead.